### PR TITLE
Ch-Jacoco Configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.4.5'
     id 'io.spring.dependency-management' version '1.1.7'
+    id 'jacoco'
 }
 
 group = 'com.itimpulse'
@@ -34,8 +35,23 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation 'com.h2database:h2'
 }
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+jacoco {
+    toolVersion = '0.8.11'
+}
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required = false
+        csv.required = false
+        html.required = true
+        html.outputLocation = layout.buildDirectory.dir('jacocoHtml')
+    }
 }

--- a/src/test/java/com/itimpulse/urlshortener/UrlShortenerOnboardingApplicationTests.java
+++ b/src/test/java/com/itimpulse/urlshortener/UrlShortenerOnboardingApplicationTests.java
@@ -2,8 +2,10 @@ package com.itimpulse.urlshortener;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class UrlShortenerOnboardingApplicationTests {
 
     @Test

--- a/src/test/java/com/itimpulse/urlshortener/validations/ShortUrlIdValidatorTest.java
+++ b/src/test/java/com/itimpulse/urlshortener/validations/ShortUrlIdValidatorTest.java
@@ -1,0 +1,40 @@
+package com.itimpulse.urlshortener.validations;
+ 
+import com.itimpulse.urlshortener.dto.ShortenUrlRequestDto;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+ 
+import java.util.Set;
+ 
+import static org.junit.jupiter.api.Assertions.*;
+ 
+class ShortUrlIdValidatorTest {
+    private static ValidatorFactory validatorFactory;
+    private static Validator validator;
+ 
+    @BeforeAll
+    static void setUp() {
+        validatorFactory = Validation.buildDefaultValidatorFactory();
+        validator = validatorFactory.getValidator();
+    }
+ 
+    @AfterAll
+    static void tearDown() {
+        validatorFactory.close();
+    }
+ 
+   @Test
+   void validCustomId_passesAllRules() {
+       ShortenUrlRequestDto dto = new ShortenUrlRequestDto();
+       dto.setLongUrl("https://example.com");
+       dto.setCustomId("abc123");
+       Set<ConstraintViolation<ShortenUrlRequestDto>> violations = validator.validate(dto);
+       assertTrue(violations.stream().noneMatch(v -> v.getPropertyPath().toString().equals("customId")));
+   }
+}
+ 

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,7 @@
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=PostgreSQL
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.hibernate.ddl-auto=create-drop
+server.port=${SERVER_PORT:8082}


### PR DESCRIPTION
- Add Jacoco plugin
- Configure Jacoco to generate test report (HTML)
- Add unit test for custom ID validations

### Note
- The feedback and improvements given before should be done in a separate PR

### Github Issue 
- [Jacoco configuration for tests report](https://github.com/nzuwera/onboarding-url-shortener/issues/5)

### Screenshots
- The report can be found under `build/jacocoHtml`
<img width="1216" alt="Screenshot 2025-05-29 at 09 50 49" src="https://github.com/user-attachments/assets/76ace11d-bf77-4329-9de9-1858a960d0e8" />
